### PR TITLE
Feat/POST add POST module

### DIFF
--- a/Core/Inc/lcu/fsm/fsm.h
+++ b/Core/Inc/lcu/fsm/fsm.h
@@ -26,9 +26,7 @@ Functions and types have been generated with prefix "fsm_"
 // By default set to void; override this typedef or load the proper
 // header if you need
 /*** USER STATE DATA TYPE BEGIN ***/
-typedef struct {
-    void (*brake_hw_update)(bool);
-} fsm_state_data_t; //temp structure
+typedef void fsm_state_data_t;
 /*** USER STATE DATA TYPE END ***/
 // Event data object
 // By default the struct is empty; put the data of the event inside

--- a/Core/Inc/lcu/lights/brake-api.h
+++ b/Core/Inc/lcu/lights/brake-api.h
@@ -21,7 +21,7 @@
  * \retval          PAL_RC_OK on success, an error otherwise:
  * \retval          PAL_RC_NULL_POINTER if any of the pointer parameters are NULL.
  */
-enum BrakeReturnCode brake_api_init(brake_update update);
+enum BrakeReturnCode brake_api_init(brake_update update, bool (*brake_hw_start)(void));
 
 /*!
  * \brief           set brake status.

--- a/Core/Inc/lcu/lights/brake-api.h
+++ b/Core/Inc/lcu/lights/brake-api.h
@@ -17,11 +17,12 @@
  * \brief           Initialize the brake_data.
  *
  * \param[in]       update: pointer to brake_update function
+ * \param[in]       start: pointer to brake_start function
  *
  * \retval          PAL_RC_OK on success, an error otherwise:
  * \retval          PAL_RC_NULL_POINTER if any of the pointer parameters are NULL.
  */
-enum BrakeReturnCode brake_api_init(brake_update update, bool (*brake_hw_start)(void));
+enum BrakeReturnCode brake_api_init(brake_update update, brake_start start);
 
 /*!
  * \brief           set brake status.

--- a/Core/Inc/lcu/lights/brake.h
+++ b/Core/Inc/lcu/lights/brake.h
@@ -19,6 +19,14 @@
 typedef void (*brake_update)(bool status);
 
 /*!
+ * \brief       Type definition for the function pointer of the hardware brake update.
+ *
+ * \retval      true: hardware started successfully.
+ * \retval      false: failed to start hardware interface.
+ */
+typedef bool (*brake_start)(void);
+
+/*!
  * \brief           A structure that encapsulates data and functions required to
  *                  handle brake management.
  */

--- a/Core/Inc/lcu/lights/brake.h
+++ b/Core/Inc/lcu/lights/brake.h
@@ -33,7 +33,8 @@ struct BrakeHandler {
 enum BrakeReturnCode {
     BRAKE_RC_OK,               /*!< Everything is fine. */
     BRAKE_RC_INVALID_ARGUMENT, /*!< Invalid parameter data. */
-    BRAKE_RC_NULL_POINTER      /*!< Unexpected NULL pointer. */
+    BRAKE_RC_NULL_POINTER,     /*!< Unexpected NULL pointer. */
+    BRAKE_RC_INIT_ERROR
 };
 
 #endif // BRAKE_H

--- a/Core/Inc/lcu/lights/brake.h
+++ b/Core/Inc/lcu/lights/brake.h
@@ -19,7 +19,7 @@
 typedef void (*brake_update)(bool status);
 
 /*!
- * \brief       Type definition for the function pointer of the hardware brake update.
+ * \brief       Type definition for the function pointer of the hardware brake start.
  *
  * \retval      true: hardware started successfully.
  * \retval      false: failed to start hardware interface.

--- a/Core/Inc/lcu/post.h
+++ b/Core/Inc/lcu/post.h
@@ -1,0 +1,30 @@
+#ifndef POST_H
+#define POST_H
+
+#include <stdint.h>
+
+/*!
+ * \brief Possible return codes for POST functions
+ */
+enum PostReturnCode {
+    POST_RC_OK,            /*!< All tests passed*/
+    POST_RC_UNINITIALIZED, /*!< A module is uninitialized*/
+    POST_RC_NULL_POINTER   /*!< A null pointer is provided*/
+};
+
+struct PostInitData {
+    void (*brake_hw_update)(bool);
+    bool (*brake_hw_start)(void);
+};
+
+/*!
+ * \brief Run power-on self tests.
+ * \param Init Pointer to PostInitData struct containing initialization data.
+ *
+ * \retval POST_RC_OK if all tests pass
+ * \retval POST_RC_UNINITIALIZED if a module is uninitialized
+ * \retval POST_RC_NULL_POINTER if a null pointer is provided
+ */
+enum PostReturnCode post_init(struct PostInitData *Init);
+
+#endif /* ifndef POST_H */

--- a/Core/Inc/lcu/post.h
+++ b/Core/Inc/lcu/post.h
@@ -2,6 +2,7 @@
 #define POST_H
 
 #include <stdint.h>
+#include <brake.h>
 
 /*!
  * \brief Possible return codes for POST functions
@@ -13,8 +14,8 @@ enum PostReturnCode {
 };
 
 struct PostInitData {
-    void (*brake_hw_update)(bool);
-    bool (*brake_hw_start)(void);
+    brake_update brake_update_fn;
+    brake_start brake_start_fn;
 };
 
 /*!

--- a/Core/Inc/lcu/post.h
+++ b/Core/Inc/lcu/post.h
@@ -14,8 +14,8 @@ enum PostReturnCode {
 };
 
 struct PostInitData {
-    brake_update brake_update_fn;
-    brake_start brake_start_fn;
+    brake_update brake_update_callback;
+    brake_start brake_start_callback;
 };
 
 /*!

--- a/Core/Src/lcu/fsm/fsm.c
+++ b/Core/Src/lcu/fsm/fsm.c
@@ -18,6 +18,7 @@ Functions and types have been generated with prefix "fsm_"
 /*** USER CODE BEGIN MACROS ***/
 #include "brake-api.h"
 #include "eagletrt-api.h"
+#include "post.h"
 /*** USER CODE END MACROS ***/
 
 // GLOBALS
@@ -80,8 +81,8 @@ fsm_state_t fsm_do_init(fsm_state_data_t *data) {
     fsm_state_t next_state = FSM_STATE_IDLE;
 
     /*** USER CODE BEGIN DO_INIT ***/
-    //TODO: move this to the post module
-    if (brake_api_init(data->brake_hw_update) != BRAKE_RC_OK) {
+    struct PostInitData *init = (struct PostInitData *)data;
+    if (post_init(init) != POST_RC_OK) {
         next_state = FSM_STATE_FATAL;
     }
     /*** USER CODE END DO_INIT ***/

--- a/Core/Src/lcu/lights/brake-api.c
+++ b/Core/Src/lcu/lights/brake-api.c
@@ -15,11 +15,11 @@
 
 EAGLETRT_STATIC struct BrakeHandler brake_handler;
 
-enum BrakeReturnCode brake_api_init(brake_update update, bool (*brake_hw_start)(void)) {
+enum BrakeReturnCode brake_api_init(brake_update update, brake_start start) {
     if (update == NULL) {
         return BRAKE_RC_NULL_POINTER;
     }
-    if (brake_hw_start() == false) {
+    if (start() == false) {
         return BRAKE_RC_INIT_ERROR;
     }
     brake_handler.status = false;

--- a/Core/Src/lcu/lights/brake-api.c
+++ b/Core/Src/lcu/lights/brake-api.c
@@ -16,7 +16,7 @@
 EAGLETRT_STATIC struct BrakeHandler brake_handler;
 
 enum BrakeReturnCode brake_api_init(brake_update update, brake_start start) {
-    if (update == NULL) {
+    if (update == NULL || start == NULL) {
         return BRAKE_RC_NULL_POINTER;
     }
     if (start() == false) {

--- a/Core/Src/lcu/lights/brake-api.c
+++ b/Core/Src/lcu/lights/brake-api.c
@@ -15,9 +15,12 @@
 
 EAGLETRT_STATIC struct BrakeHandler brake_handler;
 
-enum BrakeReturnCode brake_api_init(brake_update update) {
+enum BrakeReturnCode brake_api_init(brake_update update, bool (*brake_hw_start)(void)) {
     if (update == NULL) {
         return BRAKE_RC_NULL_POINTER;
+    }
+    if (brake_hw_start() == false) {
+        return BRAKE_RC_INIT_ERROR;
     }
     brake_handler.status = false;
     brake_handler.update = update;

--- a/Core/Src/lcu/post.c
+++ b/Core/Src/lcu/post.c
@@ -6,7 +6,7 @@ enum PostReturnCode post_init(struct PostInitData *init) {
     if (init == NULL) {
         return POST_RC_NULL_POINTER;
     }
-    if (brake_api_init(init->brake_hw_update, init->brake_hw_start) != BRAKE_RC_OK) {
+    if (brake_api_init(init->brake_update_fn, init->brake_start_fn) != BRAKE_RC_OK) {
         return POST_RC_UNINITIALIZED;
     }
     return POST_RC_OK;

--- a/Core/Src/lcu/post.c
+++ b/Core/Src/lcu/post.c
@@ -1,0 +1,13 @@
+#include <stddef.h>
+#include "post.h"
+#include "brake-api.h"
+
+enum PostReturnCode post_init(struct PostInitData *init) {
+    if (init == NULL) {
+        return POST_RC_NULL_POINTER;
+    }
+    if (brake_api_init(init->brake_hw_update, init->brake_hw_start) != BRAKE_RC_OK) {
+        return POST_RC_UNINITIALIZED;
+    }
+    return POST_RC_OK;
+}

--- a/Core/Src/lcu/post.c
+++ b/Core/Src/lcu/post.c
@@ -6,7 +6,7 @@ enum PostReturnCode post_init(struct PostInitData *init) {
     if (init == NULL) {
         return POST_RC_NULL_POINTER;
     }
-    if (brake_api_init(init->brake_update_fn, init->brake_start_fn) != BRAKE_RC_OK) {
+    if (brake_api_init(init->brake_update_callback, init->brake_start_callback) != BRAKE_RC_OK) {
         return POST_RC_UNINITIALIZED;
     }
     return POST_RC_OK;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -28,6 +28,7 @@
 #include "fsm.h"
 #include "eagletrt-api.h"
 #include "brake-api.h"
+#include "post.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -98,12 +99,8 @@ int main(void) {
     /* USER CODE BEGIN 2 */
     //TODO: use future post module struct
     //temp!! i can cast function pointers to object pointers, this will be replaced by a post data structure in the future
-    fsm_state_data_t brake_init = { .brake_hw_update = tim_brake_update };
-    fsm_state_t current_state = fsm_run_state(FSM_STATE_INIT, &brake_init);
-    //TODO: move pwm start inside future post module
-    if (tim_brake_start() == false) {
-        current_state = FSM_STATE_FATAL;
-    }
+    struct PostInitData init = { .brake_hw_update = tim_brake_update, .brake_hw_start = tim_brake_start };
+    fsm_state_t current_state = fsm_run_state(FSM_STATE_INIT, (fsm_state_data_t *)&init);
     /* USER CODE END 2 */
 
     /* Infinite loop */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -99,7 +99,7 @@ int main(void) {
     /* USER CODE BEGIN 2 */
     //TODO: use future post module struct
     //temp!! i can cast function pointers to object pointers, this will be replaced by a post data structure in the future
-    struct PostInitData init = { .brake_hw_update = tim_brake_update, .brake_hw_start = tim_brake_start };
+    struct PostInitData init = { .brake_update_fn = tim_brake_update, .brake_start_fn = tim_brake_start };
     fsm_state_t current_state = fsm_run_state(FSM_STATE_INIT, (fsm_state_data_t *)&init);
     /* USER CODE END 2 */
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -99,7 +99,7 @@ int main(void) {
     /* USER CODE BEGIN 2 */
     //TODO: use future post module struct
     //temp!! i can cast function pointers to object pointers, this will be replaced by a post data structure in the future
-    struct PostInitData init = { .brake_update_fn = tim_brake_update, .brake_start_fn = tim_brake_start };
+    struct PostInitData init = { .brake_update_callback = tim_brake_update, .brake_start_callback = tim_brake_start };
     fsm_state_t current_state = fsm_run_state(FSM_STATE_INIT, (fsm_state_data_t *)&init);
     /* USER CODE END 2 */
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ build_flags =
     -ICore/Inc
     -ICore/Inc/lcu/fsm
     -ICore/Inc/lcu/lights
+    -ICore/Inc/lcu
     -IDrivers/STM32C0xx_HAL_Driver/Inc
     -IDrivers/STM32C0xx_HAL_Driver/Inc/Legacy
     -IDrivers/CMSIS/Include


### PR DESCRIPTION
# Purpose
Introduces a post module for proper initialisation management, closes #10

# Overview
Implement POST module (`post.h`, `post.c`)
Expand `brake_init` to handle calling the hardware start callback (`brake-api.h`, `brake-api.c`)
Route initialization throgh the post module (`fms.c`/`main.c`)

# Guidance
Pretty much every file was involved somewhat.
Check if the initialization flow works and allows the board to initialize correctly or transition to fatal state.
